### PR TITLE
Get cache table details using `dry.` run of cached calls.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: cachemeifyoucan
 Type: Package
 Title: Cache Me If You Can
-Version: 0.2.1.3
+Version: 0.2.1.4
 Description: One of the most frustrating parts about being a data scientist
     is waiting for data or other large downloads. This package offers a caching
     layer for arbitrary functions that relies on a PostgreSQL backend.

--- a/R/cache.R
+++ b/R/cache.R
@@ -239,8 +239,8 @@ cache <- function(uncached_function, key, salt, con, prefix = deparse(uncached_f
   ## Check "force.", "dry." name collision
   lapply(c("force.", "dry."), function(x) {
     if (x %in% names(formals(cached_function))) {
-      stop(sQuote(x), " is a reserved argument in caching layer, ",
-      "collision with formals in the cached function.", call. = FALSE)
+      stop(sQuote(x), " is a reserved argument in cachemeifyoucan layer, ",
+      "collision with formals in the cachemeifyoucan function.", call. = FALSE)
     }
   })
 
@@ -429,16 +429,16 @@ debug_info <- function(fcn_call, keys) {
   })
 
   if (isTRUE(getOption('cachemeifyoucan.debug'))) {
-    msg <- pp(paste(
+    msg <- paste(
       c(
-        "Using table name: #{ fcn_call$table }",
+        paste0("Using table name: ", fcn_call$table),
         "Shard dimensions:",
         shard_info,
-        "#{ length(cached_keys) } cached keys",
-        "#{ length(uncached_keys) } uncached keys"
+        paste0(length(cached_keys)  , " cached keys"),
+        paste0(length(uncached_keys), " uncached keys")
       ),
       collapse = "\n"
-    ))
+    )
     message(msg)
   }
 

--- a/R/cache.R
+++ b/R/cache.R
@@ -445,7 +445,7 @@ debug_info <- function(fcn_call, keys) {
     cached_keys = cached_keys,
     uncached_keys = uncached_keys,
     shard_names = shard_names,
-    table_name = fcn_call$table_name
+    table_name = fcn_call$table
   )
 }
 

--- a/R/cache.R
+++ b/R/cache.R
@@ -430,13 +430,14 @@ debug_info <- function(fcn_call, keys) {
 
   if (isTRUE(getOption('cachemeifyoucan.debug'))) {
     msg <- pp(paste(
-      "Using table name: #{ fcn_call$table }",
-      "Shard dimensions:",
-      shard_info,
-      "#{ length(cached_keys) } cached keys",
-      "#{ length(uncached_keys) } uncached keys",
-      collapse = "\n",
-      sep = "\n"
+      c(
+        "Using table name: #{ fcn_call$table }",
+        "Shard dimensions:",
+        shard_info,
+        "#{ length(cached_keys) } cached keys",
+        "#{ length(uncached_keys) } uncached keys"
+      ),
+      collapse = "\n"
     ))
     message(msg)
   }


### PR DESCRIPTION
Allow end users to pass a `dry.` parameter to inspect the cache table status without actually executing the calls.  Replaces #103 
