### PR TITLE
`update_cache_salt` now throws some important e

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: cachemeifyoucan
 Type: Package
 Title: Cache Me If You Can
-Version: 0.2.3.2
+Version: 0.2.3.3
 Description: One of the most frustrating parts about being a data scientist
     is waiting for data or other large downloads. This package offers a caching
     layer for arbitrary functions that relies on a PostgreSQL backend.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# Version 0.2.3.3
+* Update the update_cache_salt utility to be more proof.
+
+# Version 0.2.3.2
+* Add a utility to update cache salts.
+
 # Version 0.2.3.1
 * Switched to using dbtest::db_test_that from the latest version of dbtest.
 
@@ -20,7 +26,7 @@
 # Version 0.2.1.2
 
 * Numeric values were being recorded using the `real` data type,
-  which only supports [6 digits](http://www.postgresql.org/docs/9.1/static/datatype-numeric.html) 
+  which only supports [6 digits](http://www.postgresql.org/docs/9.1/static/datatype-numeric.html)
   of precision. This was fixed by switching these column types to
   the `numeric` data type.
 

--- a/R/migrations.R
+++ b/R/migrations.R
@@ -29,12 +29,14 @@ update_cache_salt <- function(dbconn, prefix, old_salt, new_salt) {
 }
 
 copy_shard <- function(dbconn, old_shard_name, new_shard_name) {
+  if (!DBI::dbExistsTable(dbconn, old_shard_name)) stop("Old shard doesn't exist.  There's nothing to migrate.")
+  if (DBI::dbExistsTable(dbconn, new_shard_name)) stop("Shard table already exists. Don't want to copy over existing data.")
+
   fields <- names(DBI::dbGetQuery(dbconn, sprintf("SELECT * FROM %s LIMIT 1", old_shard_name)))
   id_col <- grep("^(.*_id|ids?)$", fields, value = TRUE)
   if (length(id_col) > 1) stop("More than one possible id column found.")
   if (length(id_col) < 1) stop("No id column found in shard. Not able to add an index")
 
-  if (DBI::dbExistsTable(dbconn, new_shard_name)) stop("Shard table already exists. Can't create a new table.")
   query <- sprintf("CREATE TABLE %s AS TABLE %s", new_shard_name, old_shard_name)
   DBI::dbGetQuery(dbconn, query)
   add_index(dbconn, new_shard_name, id_col)


### PR DESCRIPTION
`update_cache_salt` now throws some important errors:
1. Errors when the source shard don't exists.
2. Errors when the destination shard is already present.
