### PR TITLE
Relocate where `safe_columns` is being detected

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: cachemeifyoucan
 Type: Package
 Title: Cache Me If You Can
-Version: 0.2.3.4
+Version: 0.2.3.5
 Description: One of the most frustrating parts about being a data scientist
     is waiting for data or other large downloads. This package offers a caching
     layer for arbitrary functions that relies on a PostgreSQL backend.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# Version 0.2.3.5
+* Fix `safe_column` logic to do what it actually intended.
+
 # Version 0.2.3.4
 * Add `last_cached_at` column in each shard.
 

--- a/R/cache.R
+++ b/R/cache.R
@@ -54,7 +54,7 @@
 #'   If safe_columns is a function, that function will be called.  The function
 #'   must return /code{TRUE} for this to work.  Also the function will be called
 #'   with no arguments.  This is mainly so you can write your own error message.
-#'   If safe_columns is /code{FALSE}, the additional columns will be added. 
+#'   If safe_columns is /code{FALSE}, the additional columns will be added.
 #'   Defaults \code{FALSE}.
 #' @return A function with a caching layer that does not call
 #'   \code{uncached_function} with already computed records, but retrieves

--- a/tests/testthat/test-data_integrity.R
+++ b/tests/testthat/test-data_integrity.R
@@ -25,16 +25,32 @@ describe("data integrity", {
     })
   })
 
-  test_that('it calls a custom function when safe_columns is is a function', {
-    dbtest::with_test_db({
-      called <- FALSE
-      caller <- function() { called <<- TRUE; TRUE }
-      lapply(dbListTables(test_con), function(t) dbRemoveTable(test_con, t))
-      cached_fcn <- cache(batch_data, key = c(key = "id"), c("model_version", "type"), con = test_con, prefix = prefix, safe_columns = caller)
-      cached_fcn(key = 5:1,  model_version, type)
-      expect_false(called)
-      cached_fcn(key = 1:10, model_version, type, add_column = TRUE)
-      expect_true(called)
+  describe("when safe_column is a custom function", {
+    test_that('it calls a custom function and returns without error', {
+      dbtest::with_test_db({
+        called <- FALSE
+        caller <- function(...) { called <<- TRUE; message(as.list(...)); TRUE }
+        lapply(dbListTables(test_con), function(t) dbRemoveTable(test_con, t))
+        cached_fcn <- cache(batch_data, key = c(key = "id"), c("model_version", "type"), con = test_con, prefix = prefix, safe_columns = caller)
+        cached_fcn(key = 5:1,  model_version, type)
+        expect_false(called)
+        cached_fcn(key = 1:10, model_version, type, add_column = TRUE)
+        expect_true(called)
+      })
+    })
+
+    test_that('it calls a custom function when safe_columns is is a function', {
+      dbtest::with_test_db({
+        called <- FALSE
+        error_msg <- "Safe Columns Error: Customer function detected error."
+        caller <- function(...) { called <<- TRUE; message(as.list(...)); stop(error_msg) }
+        lapply(dbListTables(test_con), function(t) dbRemoveTable(test_con, t))
+        cached_fcn <- cache(batch_data, key = c(key = "id"), c("model_version", "type"), con = test_con, prefix = prefix, safe_columns = caller)
+        cached_fcn(key = 5:1,  model_version, type)
+        expect_false(called)
+        expect_error(cached_fcn(key = 1:10, model_version, type, add_column = TRUE), error_msg)
+        expect_true(called)
+      })
     })
   })
 })


### PR DESCRIPTION
This changes moves `safe_column` to where where it detects the creation of new columns to existing shards.

Resolves issue #120 
