### PR TITLE
Add last_cached_at metadata column for existing shards

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_script:
   - Rscript -e 'if (!require("berdie")) devtools::install_github("robertzk/berdie")'
   - Rscript -e 'if (!require("covr")) devtools::install_github("kirillseva/covr")'
   - Rscript -e 'if (!require("dbtest")) devtools::install_github("avantcredit/dbtest")'
-  - Rscript -e 'devtools::install_github("peterhurford/batchman@1.0.0.9001")'
+  - Rscript -e 'if (!require("batchman")) devtools::install_github("peterhurford/batchman")'
   - Rscript -e 'devtools::install_deps(repos = "http://cran.rstudio.com", dependencies = TRUE)'
 script:
   - Rscript -e 'res <- try(devtools::check()); quit(save = "no", status = if (isTRUE(res)) { 0 } else { 1 }, runLast = FALSE)'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: cachemeifyoucan
 Type: Package
 Title: Cache Me If You Can
-Version: 0.2.3.5
+Version: 0.2.3.6
 Description: One of the most frustrating parts about being a data scientist
     is waiting for data or other large downloads. This package offers a caching
     layer for arbitrary functions that relies on a PostgreSQL backend.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# Version 0.2.3.6
+* Fix `last_cached_at` bug for existing shards.
+
 # Version 0.2.3.5
 * Fix `safe_column` logic to do what it actually intended.
 

--- a/R/db.R
+++ b/R/db.R
@@ -90,8 +90,7 @@ db2df <- function(df, dbconn, key) {
 #' @param key. Identifier of database table.
 add_index <- function(dbconn, tblname, key, idx_name = paste0("idx_", digest::digest(tblname))) {
   if (!tolower(substring(idx_name, 1, 1)) %in% letters) {
-    stop(sprintf("Invalid index name '%s': must begin with an alphabetic character",
-                 idx_name))
+    stop(sprintf("Invalid index name '%s': must begin with an alphabetic character", idx_name))
   }
   DBI::dbGetQuery(dbconn, paste0("CREATE INDEX ", idx_name, " ON ", tblname, "(", key, ")"))
   TRUE

--- a/R/db.R
+++ b/R/db.R
@@ -358,7 +358,6 @@ write_data_safely <- function(dbconn, tblname, df, key, safe_columns) {
 
       for (index in which(missing_cols)) {
         col <- new_names[index]
-        col_name_raw <- new_names_raw[index]
         if (!all(vapply(col, nchar, integer(1)) > 0))
           stop("Failed to retrieve MD5 hashed column names in write_data_safely")
         # TODO: (RK) Figure out how to filter all NA columns without wrecking

--- a/R/db.R
+++ b/R/db.R
@@ -392,6 +392,7 @@ write_data_safely <- function(dbconn, tblname, df, key, safe_columns) {
     message("An error occurred: ", e)
     message("Rollback!")
     DBI::dbRollback(dbconn)
+    stop(e)
   },
   finally = {
     DBI::dbGetQuery(dbconn, "COMMIT")

--- a/R/db.R
+++ b/R/db.R
@@ -368,7 +368,6 @@ write_data_safely <- function(dbconn, tblname, df, key, safe_columns) {
         else col_type <- CLASS_MAP[[class(df[[index]])[1]]]
 
         sql <- paste("ALTER TABLE", tblname, "ADD COLUMN", col, col_type)
-
         suppressWarnings(DBI::dbGetQuery(dbconn, sql))
       }
 

--- a/tests/testthat/test-data_integrity.R
+++ b/tests/testthat/test-data_integrity.R
@@ -16,12 +16,14 @@ describe("data integrity", {
     }, no_check = TRUE)
   })
 
-  test_that('it crashes when trying to expand a table on new column when safe_columns is TRUE', {
-    dbtest::with_test_db({
-      lapply(dbListTables(test_con), function(t) dbRemoveTable(test_con, t))
-      cached_fcn <- cache(batch_data, key = c(key = "id"), c("model_version", "type"), con = test_con, prefix = prefix, safe_columns = TRUE)
-      cached_fcn(key = 5:1,  model_version, type)
-      expect_error(cached_fcn(key = 1:10, model_version, type, add_column = TRUE))
+  describe("when safe_column is TRUE", {
+    test_that('it crashes when trying to expand a table on new column', {
+      dbtest::with_test_db({
+        lapply(dbListTables(test_con), function(t) dbRemoveTable(test_con, t))
+        cached_fcn <- cache(batch_data, key = c(key = "id"), c("model_version", "type"), con = test_con, prefix = prefix, safe_columns = TRUE)
+        cached_fcn(key = 5:1,  model_version, type)
+        expect_error(cached_fcn(key = 1:10, model_version, type, add_column = TRUE))
+      })
     })
   })
 

--- a/tests/testthat/test-data_integrity.R
+++ b/tests/testthat/test-data_integrity.R
@@ -17,42 +17,33 @@ describe("data integrity", {
   })
 
   describe("when safe_column is TRUE", {
-    test_that('it crashes when trying to expand a table on new column', {
-      dbtest::with_test_db({
-        lapply(dbListTables(test_con), function(t) dbRemoveTable(test_con, t))
-        cached_fcn <- cache(batch_data, key = c(key = "id"), c("model_version", "type"), con = test_con, prefix = prefix, safe_columns = TRUE)
-        cached_fcn(key = 5:1,  model_version, type)
-        expect_error(cached_fcn(key = 1:10, model_version, type, add_column = TRUE))
-      })
+    db_test_that('it crashes when trying to expand a table on new column', {
+      cached_fcn <- cache(batch_data, key = c(key = "id"), c("model_version", "type"), con = test_con, prefix = prefix, safe_columns = TRUE)
+      cached_fcn(key = 5:1,  model_version, type)
+      expect_error(cached_fcn(key = 1:10, model_version, type, add_column = TRUE))
     })
   })
 
   describe("when safe_column is a custom function", {
-    test_that('it calls a custom function and returns without error', {
-      dbtest::with_test_db({
-        called <- FALSE
-        caller <- function(...) { called <<- TRUE; message(as.list(...)); TRUE }
-        lapply(dbListTables(test_con), function(t) dbRemoveTable(test_con, t))
-        cached_fcn <- cache(batch_data, key = c(key = "id"), c("model_version", "type"), con = test_con, prefix = prefix, safe_columns = caller)
-        cached_fcn(key = 5:1,  model_version, type)
-        expect_false(called)
-        cached_fcn(key = 1:10, model_version, type, add_column = TRUE)
-        expect_true(called)
-      })
+    db_test_that('it calls a custom function and returns without error', {
+      called <- FALSE
+      caller <- function(...) { called <<- TRUE; message(as.list(...)); TRUE }
+      cached_fcn <- cache(batch_data, key = c(key = "id"), c("model_version", "type"), con = test_con, prefix = prefix, safe_columns = caller)
+      cached_fcn(key = 5:1,  model_version, type)
+      expect_false(called)
+      cached_fcn(key = 1:10, model_version, type, add_column = TRUE)
+      expect_true(called)
     })
 
-    test_that('it calls a custom function when safe_columns is is a function', {
-      dbtest::with_test_db({
-        called <- FALSE
-        error_msg <- "Safe Columns Error: Customer function detected error."
-        caller <- function(...) { called <<- TRUE; message(as.list(...)); stop(error_msg) }
-        lapply(dbListTables(test_con), function(t) dbRemoveTable(test_con, t))
-        cached_fcn <- cache(batch_data, key = c(key = "id"), c("model_version", "type"), con = test_con, prefix = prefix, safe_columns = caller)
-        cached_fcn(key = 5:1,  model_version, type)
-        expect_false(called)
-        expect_error(cached_fcn(key = 1:10, model_version, type, add_column = TRUE), error_msg)
-        expect_true(called)
-      })
+    db_test_that('it calls a custom function when safe_columns is is a function', {
+      called <- FALSE
+      error_msg <- "Safe Columns Error: Customer function detected error."
+      caller <- function(...) { called <<- TRUE; message(as.list(...)); stop(error_msg) }
+      cached_fcn <- cache(batch_data, key = c(key = "id"), c("model_version", "type"), con = test_con, prefix = prefix, safe_columns = caller)
+      cached_fcn(key = 5:1,  model_version, type)
+      expect_false(called)
+      expect_error(cached_fcn(key = 1:10, model_version, type, add_column = TRUE), error_msg)
+      expect_true(called)
     })
   })
 })

--- a/tests/testthat/test-last_cached_at.R
+++ b/tests/testthat/test-last_cached_at.R
@@ -39,55 +39,47 @@ describe("last_cached_at", {
   })
 
   describe("when last_cached_at does not yet exist in shard", {
-    test_that("it adds the last_cached_at column with new data", {
-      dbtest::with_test_db({
-        lapply(dbListTables(test_con), function(t) dbRemoveTable(test_con, t))
+    db_test_that("it adds the last_cached_at column with new data", {
+      cached_fcn <- cache(batch_data, key = c(key = "id"), c("model_version", "type"), con = test_con, prefix = prefix)
+      cached_fcn(key = 5:1,  model_version, type)
 
-        cached_fcn <- cache(batch_data, key = c(key = "id"), c("model_version", "type"), con = test_con, prefix = prefix)
-        cached_fcn(key = 5:1,  model_version, type)
+      shard_name <- cached_fcn(key = 5:1,  model_version, type, dry. = TRUE)$shard_names[[1]]
 
-        shard_name <- cached_fcn(key = 5:1,  model_version, type, dry. = TRUE)$shard_names[[1]]
+      # Drop last_cached_at column to mimic tables in older versions of cmiyc
+      DBI::dbGetQuery(test_con, paste("alter table", shard_name, "drop column", "last_cached_at"))
 
-        # Drop last_cached_at column to mimic tables in older versions of cmiyc
-        DBI::dbGetQuery(test_con, paste("alter table", shard_name, "drop column", "last_cached_at"))
+      df <- DBI::dbGetQuery(test_con, paste("select * from ", shard_name, "limit 1"))
+      expect_false("last_cached_at" %in% names(df))
 
-        df <- DBI::dbGetQuery(test_con, paste("select * from ", shard_name, "limit 1"))
-        expect_false("last_cached_at" %in% names(df))
+      # Cache new data
+      cached_fcn(key = 5:10,  model_version, type)
 
-        # Cache new data
-        cached_fcn(key = 5:10,  model_version, type)
-
-        # Verify that the last_cached_at column exists
-        df <- DBI::dbGetQuery(test_con, paste("select * from ", shard_name, "limit 1"))
-        expect_true("last_cached_at" %in% names(df))
-      })
+      # Verify that the last_cached_at column exists
+      df <- DBI::dbGetQuery(test_con, paste("select * from ", shard_name, "limit 1"))
+      expect_true("last_cached_at" %in% names(df))
     })
 
-    test_that("it adds the last_cached_at column with forced data", {
-      dbtest::with_test_db({
-        lapply(dbListTables(test_con), function(t) dbRemoveTable(test_con, t))
+    db_test_that("it adds the last_cached_at column with forced data", {
+      cached_fcn <- cache(batch_data, key = c(key = "id"), c("model_version", "type"), con = test_con, prefix = prefix)
+      cached_fcn(key = 5:1,  model_version, type)
 
-        cached_fcn <- cache(batch_data, key = c(key = "id"), c("model_version", "type"), con = test_con, prefix = prefix)
-        cached_fcn(key = 5:1,  model_version, type)
+      shard_name <- cached_fcn(key = 5:1,  model_version, type, dry. = TRUE)$shard_names[[1]]
 
-        shard_name <- cached_fcn(key = 5:1,  model_version, type, dry. = TRUE)$shard_names[[1]]
+      # Drop last_cached_at column to mimic tables in older versions of cmiyc
+      DBI::dbGetQuery(test_con, paste("alter table", shard_name, "drop column", "last_cached_at"))
 
-        # Drop last_cached_at column to mimic tables in older versions of cmiyc
-        DBI::dbGetQuery(test_con, paste("alter table", shard_name, "drop column", "last_cached_at"))
+      df <- DBI::dbGetQuery(test_con, paste("select * from ", shard_name, "limit 1"))
+      expect_false("last_cached_at" %in% names(df))
 
-        df <- DBI::dbGetQuery(test_con, paste("select * from ", shard_name, "limit 1"))
-        expect_false("last_cached_at" %in% names(df))
+      # 1. Unforced cache retrival doesn't change anything
+      cached_fcn(key = 5:1,  model_version, type)
+      df <- DBI::dbGetQuery(test_con, paste("select * from ", shard_name, "limit 1"))
+      expect_false("last_cached_at" %in% names(df))
 
-        # 1. Unforced cache retrival doesn't change anything
-        cached_fcn(key = 5:1,  model_version, type)
-        df <- DBI::dbGetQuery(test_con, paste("select * from ", shard_name, "limit 1"))
-        expect_false("last_cached_at" %in% names(df))
-
-        # 2. Force cache data adds last_cached_at column
-        cached_fcn(key = 5:1,  model_version, type, force. = TRUE)
-        df <- DBI::dbGetQuery(test_con, paste("select * from ", shard_name, "limit 1"))
-        expect_true("last_cached_at" %in% names(df))
-      })
+      # 2. Force cache data adds last_cached_at column
+      cached_fcn(key = 5:1,  model_version, type, force. = TRUE)
+      df <- DBI::dbGetQuery(test_con, paste("select * from ", shard_name, "limit 1"))
+      expect_true("last_cached_at" %in% names(df))
     })
   })
 })

--- a/tests/testthat/test-last_cached_at.R
+++ b/tests/testthat/test-last_cached_at.R
@@ -37,4 +37,57 @@ describe("last_cached_at", {
     expect_false(identical(sample_rows$last_cached_at, new_sample_rows$last_cached_at))
     expect_true(all(sample_rows$last_cached_at < new_sample_rows$last_cached_at))
   })
+
+  describe("when last_cached_at does not yet exist in shard", {
+    test_that("it adds the last_cached_at column with new data", {
+      dbtest::with_test_db({
+        lapply(dbListTables(test_con), function(t) dbRemoveTable(test_con, t))
+
+        cached_fcn <- cache(batch_data, key = c(key = "id"), c("model_version", "type"), con = test_con, prefix = prefix)
+        cached_fcn(key = 5:1,  model_version, type)
+
+        shard_name <- cached_fcn(key = 5:1,  model_version, type, dry. = TRUE)$shard_names[[1]]
+
+        # Drop last_cached_at column to mimic tables in older versions of cmiyc
+        DBI::dbGetQuery(test_con, paste("alter table", shard_name, "drop column", "last_cached_at"))
+
+        df <- DBI::dbGetQuery(test_con, paste("select * from ", shard_name, "limit 1"))
+        expect_false("last_cached_at" %in% names(df))
+
+        # Cache new data
+        cached_fcn(key = 5:10,  model_version, type)
+
+        # Verify that the last_cached_at column exists
+        df <- DBI::dbGetQuery(test_con, paste("select * from ", shard_name, "limit 1"))
+        expect_true("last_cached_at" %in% names(df))
+      })
+    })
+
+    test_that("it adds the last_cached_at column with forced data", {
+      dbtest::with_test_db({
+        lapply(dbListTables(test_con), function(t) dbRemoveTable(test_con, t))
+
+        cached_fcn <- cache(batch_data, key = c(key = "id"), c("model_version", "type"), con = test_con, prefix = prefix)
+        cached_fcn(key = 5:1,  model_version, type)
+
+        shard_name <- cached_fcn(key = 5:1,  model_version, type, dry. = TRUE)$shard_names[[1]]
+
+        # Drop last_cached_at column to mimic tables in older versions of cmiyc
+        DBI::dbGetQuery(test_con, paste("alter table", shard_name, "drop column", "last_cached_at"))
+
+        df <- DBI::dbGetQuery(test_con, paste("select * from ", shard_name, "limit 1"))
+        expect_false("last_cached_at" %in% names(df))
+
+        # 1. Unforced cache retrival doesn't change anything
+        cached_fcn(key = 5:1,  model_version, type)
+        df <- DBI::dbGetQuery(test_con, paste("select * from ", shard_name, "limit 1"))
+        expect_false("last_cached_at" %in% names(df))
+
+        # 2. Force cache data adds last_cached_at column
+        cached_fcn(key = 5:1,  model_version, type, force. = TRUE)
+        df <- DBI::dbGetQuery(test_con, paste("select * from ", shard_name, "limit 1"))
+        expect_true("last_cached_at" %in% names(df))
+      })
+    })
+  })
 })


### PR DESCRIPTION
It was discovered that existing shards that don't have a `last_cached_at` column (ie. created before cachemeifyoucan version 0.2.3.4) doesn't work correctly with `safe_columns`.  That issue is now addressed in this PR.
