### PR TITLE
Change ref on RPostgres

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Suggests:
     batchman (>= 1.0.0.9001)
 Remotes:
     robertzk/berdie,
-    robertzk/RPostgres@fix_type_issues2,
+    robertzk/RPostgres@types_and_more_info2,
     avantcredit/dbtest
 License: MIT + file LICENSE
 LazyData: true


### PR DESCRIPTION
```
* installing *source* package ‘cachemeifyoucan’ ...
** R
** inst
** tests
** preparing package for lazy loading
Error in loadNamespace(i, c(lib.loc, .libPaths()), versionCheck = vI[[i]]) :
  namespace ‘RPostgres’ 0.1.1 is being loaded, but >= 0.1.2 is required
ERROR: lazy loading failed for package ‘cachemeifyoucan’
* removing ‘/usr/lib64/R/library/cachemeifyoucan’
Installation failed: Command failed (1)
```